### PR TITLE
Add integer safety related functions

### DIFF
--- a/src/Basics/Extra.elm
+++ b/src/Basics/Extra.elm
@@ -2,12 +2,15 @@ module Basics.Extra
     exposing
         ( (=>)
         , swap
+        , maxSafeInteger
+        , minSafeInteger
+        , isSafeInteger
         )
 
 {-| Additional basic functions.
 
 # Tuples
-@docs (=>), swap
+@docs (=>), swap, maxSafeInteger, minSafeInteger, isSafeInteger
 -}
 
 
@@ -27,3 +30,37 @@ in CSS or Json encoders.
 swap : ( a, b ) -> ( b, a )
 swap ( a, b ) =
     ( b, a )
+
+
+{-| The maximum _safe_ value for an integer, defined as `2^53 - 1`. Anything
+larger than that and behaviour becomes mathematically unsound.
+
+    (maxSafeInteger + 1) == (maxSafeInteger + 2)
+        == True
+-}
+maxSafeInteger : number
+maxSafeInteger =
+    9007199254740991
+
+
+{-| The minimum _safe_ value for an integer, defined as `-(2^53 - 1)`. Anything
+smaller than that, and behaviour becomes mathematically unsound.
+
+    (minSafeInteger - 1) == (minSafeInteger - 2)
+        == True
+-}
+minSafeInteger : number
+minSafeInteger =
+    -9007199254740991
+
+
+{-| Checks if a given integer is within the safe range, meaning it is between
+`-(2^53 - 1)` and `2^53 - 1`.
+
+    isSafeInteger 5 == True
+    isSafeInteger maxSafeInteger == True
+    isSafeInteger (maxSafeInteger + 1) == False
+-}
+isSafeInteger : Int -> Bool
+isSafeInteger number =
+    minSafeInteger <= number && maxSafeInteger >= number


### PR DESCRIPTION
- `min/maxSafeInteger`: explain the limits of the platform. Also, useful as ranges for generating random numbers
- `isSafeInteger` is useful when verifying input. JSON decoding no longer accepts unsafe integers, but there are still a number of ways to introduce these. Having a way to bound-check makes sense.