### PR TITLE
Add safe division functions

### DIFF
--- a/src/Basics/Extra.elm
+++ b/src/Basics/Extra.elm
@@ -1,7 +1,7 @@
 module Basics.Extra exposing
     ( swap
     , maxSafeInteger, minSafeInteger, isSafeInteger
-    , fractionalModBy, safeModBy
+    , fractionalModBy, safeModBy, safeRemainderBy, safeDivide, safeIntegerDivide
     , inDegrees, inRadians, inTurns
     , flip, curry, uncurry
     )
@@ -21,7 +21,7 @@ module Basics.Extra exposing
 
 # Fancier Math
 
-@docs fractionalModBy, safeModBy
+@docs fractionalModBy, safeModBy, safeRemainderBy, safeDivide, safeIntegerDivide
 
 
 # Angles
@@ -108,25 +108,122 @@ fractionalModBy modulus x =
 
 
 {-| Perform [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic)
-that doesn't crash the app if the `b` argument in `a % b` is zero.
+that doesn't crash the app if the `b` argument in `a % b` is zero. We instead return Nothing.
 
-We instead return [zero](https://www.hillelwayne.com/post/divide-by-zero/) as a default.
+    safeModBy 2 4 == Just 0
 
-    safeModBy 2 4 == 0
-
-    safeModBy 2 5 == 1
+    safeModBy 2 5 == Just 1
 
     -- the interesting part
-    safeModBy 0 4 == 0
+    safeModBy 0 4 == Nothing
+
+In many cases it makes sense to [return zero](https://www.hillelwayne.com/post/divide-by-zero/) as a default.
+You can do that by defining your own version - might be nicer to use because of returning straight `Int`!
+
+    modBy_ : Int -> Int -> Int
+    modBy_ modulus x =
+        safeModBy modulus x
+            |> Maybe.withDefault 0
+
+    modBy_ 2 4 == 0
+
+    modBy_ 2 5 == 1
+
+    -- the interesting part
+    modBy_ 0 4 == 0
+
+Use [`safeRemainderBy`](#safeRemainderBy) for a different treatment of negative
+numbers, or read Daan Leijen’s [Division and Modulus for Computer Scientists][dm]
+for more information.
+
+[dm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
 
 -}
-safeModBy : Int -> Int -> Int
+safeModBy : Int -> Int -> Maybe Int
 safeModBy modulus x =
     if modulus == 0 then
+        Nothing
+
+    else
+        Just <| modBy modulus x
+
+
+{-| Get the remainder after division.
+
+This version doesn't crash the app if the `b` argument in `a % b` is zero. We instead return Nothing.
+
+    safeRemainderBy 2 4 == Just 0
+
+    safeRemainderBy 2 5 == Just 1
+
+    -- the interesting part
+    safeRemainderBy 0 4 == Nothing
+
+In many cases it makes sense to [return zero](https://www.hillelwayne.com/post/divide-by-zero/) as a default.
+You can do that by defining your own version - might be nicer to use because of returning straight `Int`!
+
+    remainderBy_ : Int -> Int -> Int
+    remainderBy_ divisor x =
+        safeRemainderBy divisor x
+            |> Maybe.withDefault 0
+
+    remainderBy_ 2 4 == 0
+
+    remainderBy_ 2 5 == 1
+
+    -- the interesting part
+    remainderBy_ 0 4 == 0
+
+Use [`safeModBy`](#safeModBy) for a different treatment of negative
+numbers, or read Daan Leijen’s [Division and Modulus for Computer Scientists][dm]
+for more information.
+
+[dm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
+
+-}
+safeRemainderBy : Int -> Int -> Maybe Int
+safeRemainderBy divisor x =
+    if divisor == 0 then
+        Nothing
+
+    else
+        Just <| remainderBy divisor x
+
+
+{-| Floating-point division (like `/`), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
+if the divisor is zero.
+
+    safeDivide 5 2 == 2.5
+
+    -- the interesting part
+    safeDivide 5 0 == 0
+
+-}
+safeDivide : Float -> Float -> Float
+safeDivide x y =
+    if y == 0 then
         0
 
     else
-        modBy modulus x
+        x / y
+
+
+{-| Integer division (like `//`), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
+if the divisor is zero.
+
+    safeIntegerDivide 5 2 == 2
+
+    -- the interesting part
+    safeIntegerDivide 5 0 == 0
+
+-}
+safeIntegerDivide : Int -> Int -> Int
+safeIntegerDivide x y =
+    if y == 0 then
+        0
+
+    else
+        x // y
 
 
 {-| Convert standard Elm angles (radians) to degrees.

--- a/src/Basics/Extra.elm
+++ b/src/Basics/Extra.elm
@@ -1,7 +1,7 @@
 module Basics.Extra exposing
     ( swap
     , maxSafeInteger, minSafeInteger, isSafeInteger
-    , fractionalModBy
+    , fractionalModBy, safeModBy
     , inDegrees, inRadians, inTurns
     , flip, curry, uncurry
     )
@@ -21,7 +21,7 @@ module Basics.Extra exposing
 
 # Fancier Math
 
-@docs fractionalModBy
+@docs fractionalModBy, safeModBy
 
 
 # Angles
@@ -105,6 +105,28 @@ in `fractionalModBy modulus x`.
 fractionalModBy : Float -> Float -> Float
 fractionalModBy modulus x =
     x - modulus * toFloat (floor (x / modulus))
+
+
+{-| Perform [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic)
+that doesn't crash the app if the `b` argument in `a % b` is zero.
+
+We instead return [zero](https://www.hillelwayne.com/post/divide-by-zero/) as a default.
+
+    safeModBy 2 4 == 0
+
+    safeModBy 2 5 == 1
+
+    -- the interesting part
+    safeModBy 0 4 == 0
+
+-}
+safeModBy : Int -> Int -> Int
+safeModBy modulus x =
+    if modulus == 0 then
+        0
+
+    else
+        modBy modulus x
 
 
 {-| Convert standard Elm angles (radians) to degrees.

--- a/src/Basics/Extra.elm
+++ b/src/Basics/Extra.elm
@@ -108,7 +108,7 @@ fractionalModBy modulus x =
 
 
 {-| Perform [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic)
-that doesn't crash the app if the `b` argument in `a % b` is zero. We instead return Nothing.
+that doesn't crash the app if the `b` argument in `a % b` is zero. We instead return `Nothing`.
 
     safeModBy 2 4 == Just 0
 
@@ -150,7 +150,7 @@ safeModBy modulus x =
 
 {-| Get the remainder after division.
 
-This version doesn't crash the app if the `b` argument in `a % b` is zero. We instead return Nothing.
+This version doesn't crash the app if the `b` argument in `a % b` is zero. We instead return `Nothing`.
 
     safeRemainderBy 2 4 == Just 0
 
@@ -190,7 +190,7 @@ safeRemainderBy divisor x =
         Just <| remainderBy divisor x
 
 
-{-| Floating-point division (like `/`), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
+{-| Floating-point division (like Elm's `/` operator), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
 if the divisor is zero.
 
     safeDivide 5 2 == 2.5
@@ -208,7 +208,7 @@ safeDivide x y =
         x / y
 
 
-{-| Integer division (like `//`), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
+{-| Integer division (like Elm's `//` operator), [returning zero](https://www.hillelwayne.com/post/divide-by-zero/)
 if the divisor is zero.
 
     safeIntegerDivide 5 2 == 2


### PR DESCRIPTION
Today I managed to crash our app with something like `modBy (List.length items) index` where the `items` list was empty. This would have prevented it.

We could also return Maybe but the zero default seems fine, as per the link in the doc comment.